### PR TITLE
Utilize ComponentOptions and ComponentFactory to create components

### DIFF
--- a/src/component-definition.ts
+++ b/src/component-definition.ts
@@ -1,21 +1,19 @@
 import {
-  ComponentDefinition as GlimmerComponentDefinition,
-  Template
+  ComponentClass,
+  ComponentDefinition as GlimmerComponentDefinition
 } from '@glimmer/runtime';
-import { Dict } from '@glimmer/util';
 import ComponentManager from './component-manager';
-import { ComponentFactory } from './component-factory';
 import Component from './component';
+import ComponentFactory from './component-factory';
 
 export default class ComponentDefinition extends GlimmerComponentDefinition<Component> {
-  public manager: ComponentManager;
   public name: string;
-  public args: Dict<any>;
-  public ComponentClass: any;
+  public manager: ComponentManager;
+  public ComponentClass: ComponentClass;
+  public componentFactory: ComponentFactory;
 
-  constructor(name: string, manager: ComponentManager, ComponentClass: Component, args?: Dict<any>) {
+  constructor(name: string, manager: ComponentManager, ComponentClass: ComponentClass) {
     super(name, manager, ComponentClass);
-    this.name = name;
-    this.args = args;
+    this.componentFactory = new ComponentFactory(ComponentClass);
   }
 }

--- a/src/component-factory.ts
+++ b/src/component-factory.ts
@@ -1,5 +1,4 @@
-import Component from './component';
-import { ComponentOptions } from './component-options';
+import Component, { ComponentOptions } from './component';
 
 export default class ComponentFactory {
   public ComponentClass: any;

--- a/src/component-factory.ts
+++ b/src/component-factory.ts
@@ -1,9 +1,14 @@
-import { Factory } from '@glimmer/di';
-import { SerializedTemplate } from '@glimmer/wire-format';
 import Component from './component';
-import ComponentOptions from './component-options';
+import { ComponentOptions } from './component-options';
 
-export interface ComponentFactory<Component> extends Factory<Component> {
-  create( options?: ComponentOptions ): Component;
-  layoutSpec: SerializedTemplate<Component>;
+export default class ComponentFactory {
+  public ComponentClass: any;
+
+  constructor(ComponentClass: any) {
+    this.ComponentClass = ComponentClass;
+  }
+  
+  create( options: ComponentOptions ): Component {
+    return new this.ComponentClass(options);
+  }
 }

--- a/src/component-manager.ts
+++ b/src/component-manager.ts
@@ -20,8 +20,7 @@ import {
   VersionedPathReference
 } from '@glimmer/reference';
 import { Opaque } from '@glimmer/util';
-import Component from './component';
-import { ComponentOptions } from './component-options';
+import Component, { ComponentOptions } from './component';
 import ComponentDefinition from './component-definition';
 import Environment from './environment';
 

--- a/src/component-manager.ts
+++ b/src/component-manager.ts
@@ -1,4 +1,8 @@
 import {
+  getOwner,
+  setOwner
+} from '@glimmer/di';
+import {
   Bounds,
   CompiledBlock,
   ComponentManager as GlimmerComponentManager,
@@ -17,6 +21,7 @@ import {
 } from '@glimmer/reference';
 import { Opaque } from '@glimmer/util';
 import Component from './component';
+import { ComponentOptions } from './component-options';
 import ComponentDefinition from './component-definition';
 import Environment from './environment';
 
@@ -41,9 +46,12 @@ export default class ComponentManager implements GlimmerComponentManager<Compone
   }
 
   create(environment: Environment, definition: ComponentDefinition, args: EvaluatedArgs): Component {
-    let ComponentClass = definition.ComponentClass;
-    let attrs = args.named.value();
-    let component = new ComponentClass(attrs); // TODO use ComponentFactory instead
+    let options: ComponentOptions = {
+      args: args.named.value()
+    };
+    setOwner(options, getOwner(this.env));
+
+    let component = definition.componentFactory.create(options);
 
     // TODO
     // component.didInitAttrs({ attrs });

--- a/src/component-options.ts
+++ b/src/component-options.ts
@@ -1,8 +1,0 @@
-import Component from './component';
-
-export interface ComponentOptions {
-  parent?: Component;
-  hasBlock?: boolean;
-  // TODO dispatcher: EventDispatcher;
-  args?: Object;
-}

--- a/src/component-options.ts
+++ b/src/component-options.ts
@@ -1,8 +1,8 @@
 import Component from './component';
 
-export default class ComponentOptions {
-  parent: Component;
-  hasBlock: boolean;
+export interface ComponentOptions {
+  parent?: Component;
+  hasBlock?: boolean;
   // TODO dispatcher: EventDispatcher;
-  args: Object = null;
+  args?: Object;
 }

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,7 +1,8 @@
-import { getOwner, setOwner, Owner, OWNER } from '@glimmer/di';
+import { getOwner, setOwner } from '@glimmer/di';
 import { DirtyableTag } from '@glimmer/reference';
 import { Simple } from '@glimmer/runtime';
 import Environment from './environment';
+import { ComponentOptions } from './component-options';
 
 export default class Component {
   dirtinessTag = new DirtyableTag();
@@ -10,16 +11,9 @@ export default class Component {
   parent: Component = null;
   args: Object = null;
 
-  static create(args?: Object): Component {
-    return new Component(args);
-  }
-
-  constructor(args: Object = {}) {
-    let owner: Owner = getOwner(args);
-    if (owner) {
-      setOwner(this, owner);
-      delete args[OWNER];
-    }
-    this.args = args;
+  constructor(options: ComponentOptions) {
+    setOwner(this, getOwner(options));
+    this.parent = options.parent;
+    this.args = options.args;
   }
 }

--- a/src/component.ts
+++ b/src/component.ts
@@ -2,7 +2,13 @@ import { getOwner, setOwner } from '@glimmer/di';
 import { DirtyableTag } from '@glimmer/reference';
 import { Simple } from '@glimmer/runtime';
 import Environment from './environment';
-import { ComponentOptions } from './component-options';
+
+export interface ComponentOptions {
+  parent?: Component;
+  hasBlock?: boolean;
+  // TODO dispatcher: EventDispatcher;
+  args?: Object;
+}
 
 export default class Component {
   dirtinessTag = new DirtyableTag();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,5 +1,6 @@
 import {
   CompiledBlock,
+  ComponentClass,
   DOMChanges,
   DOMTreeConstruction,
   Environment as GlimmerEnvironment,
@@ -40,7 +41,7 @@ import {
   Owner
 } from '@glimmer/di';
 import Component from './component';
-import { ComponentFactory } from './component-factory';
+import ComponentFactory from './component-factory';
 import ComponentDefinition from './component-definition';
 import ComponentLayoutCompiler from './component-layout-compiler';
 import ComponentManager from './component-manager';
@@ -91,7 +92,7 @@ export default class Environment extends GlimmerEnvironment {
 
   registerComponent(specifier: string): ComponentDefinition {
     let owner: Owner = getOwner(this);
-    let ComponentClass: Component = owner.factoryFor(specifier);
+    let ComponentClass = owner.factoryFor(specifier);
     let componentDef: ComponentDefinition = new ComponentDefinition(specifier, this.componentManager, ComponentClass);
     this.components[specifier] = componentDef;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Component } from './component';
+export { default as Component, ComponentOptions } from './component';
 export { default as ComponentFactory } from './component-factory';
 export { default as ComponentDefinition } from './component-definition';
 export { default as ComponentLayoutCompiler } from './component-layout-compiler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { default as Component } from './component';
-export { ComponentFactory } from './component-factory';
+export { default as ComponentFactory } from './component-factory';
 export { default as ComponentDefinition } from './component-definition';
 export { default as ComponentLayoutCompiler } from './component-layout-compiler';
 export { default as ComponentManager } from './component-manager';

--- a/test/component-test.ts
+++ b/test/component-test.ts
@@ -1,6 +1,5 @@
 import { getOwner, setOwner, Owner } from '@glimmer/di';
-import { ComponentOptions } from '../src/component-options';
-import Component from '../src/component';
+import Component, { ComponentOptions } from '../src/component';
 
 const { module, test } = QUnit;
 

--- a/test/component-test.ts
+++ b/test/component-test.ts
@@ -1,45 +1,35 @@
 import { getOwner, setOwner, Owner } from '@glimmer/di';
+import { ComponentOptions } from '../src/component-options';
 import Component from '../src/component';
 
 const { module, test } = QUnit;
 
 module('Component');
 
-test('can be instantiated with new', function(assert) {
-  let component = new Component();
+class FakeApp implements Owner {
+  identify(specifier: string, referrer?: string) { return ''; }
+  factoryFor(specifier: string, referrer?: string) { return null; }
+  lookup(specifier: string, referrer?: string) { return null; }
+}
+
+test('can be instantiated with an owner', function(assert) {
+  let owner: Owner = new FakeApp;
+  let options: ComponentOptions = {};
+  setOwner(options, owner);
+  let component = new Component(options);
   assert.ok(component, 'component exists');
+  assert.strictEqual(getOwner(component), owner, 'owner has been set');
 });
 
-test('can be instantiated with create', function(assert) {
-  let component = Component.create();
-  assert.ok(component, 'component exists');
-});
-
-test('can be assigned args', function(assert) {
+test('can be instantiated with an owner and args', function(assert) {
+  let owner: Owner = new FakeApp;
   let args = {
     a: 'a',
     b: 'b'
   };
-  let component = Component.create(args);
+  let options: ComponentOptions = { args };
+  setOwner(options, owner);
+  let component = new Component(options);
   assert.deepEqual(component.args, args, 'args have been assigned');
-});
-
-test('can be assigned args and an owner', function(assert) {
-  class FakeApp implements Owner {
-    identify(specifier: string, referrer?: string) { return ''; }
-    factoryFor(specifier: string, referrer?: string) { return null; }
-    lookup(specifier: string, referrer?: string) { return null; }
-  }
-  let app = new FakeApp;
-
-  let args = {
-    a: 'a',
-    b: 'b'
-  };
-
-  setOwner(args, app);
-
-  let component = Component.create(args);
-  assert.deepEqual(component.args, {a: 'a', b: 'b'}, 'args have been assigned');
-  assert.strictEqual(getOwner(component), app, 'owner has been set');
+  assert.strictEqual(getOwner(component), owner, 'owner has been set');
 });

--- a/test/environment-test.ts
+++ b/test/environment-test.ts
@@ -1,6 +1,6 @@
 import { getOwner, setOwner, Owner } from '@glimmer/di';
 import { DOMTreeConstruction } from '@glimmer/runtime';
-import Environment from '../src/environment';
+import Environment, { EnvironmentOptions } from '../src/environment';
 
 const { module, test } = QUnit;
 
@@ -27,7 +27,7 @@ test('can be assigned an owner', function(assert) {
   }
   let app = new FakeApp;
 
-  let options = {};
+  let options: EnvironmentOptions = {};
   setOwner(options, app);
 
   let env = Environment.create(options);


### PR DESCRIPTION
Improves the rigor of the previous sloppy implementation, which was simply calling `new` directly on the component class. This allows for explicit declaration of options and allows for custom factory logic as well.
