### PR TITLE
Bump @glimmer/di and @glimmer/build

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -9,28 +9,28 @@ let buildOptions = {};
 
 if (process.env.BROCCOLI_ENV === 'tests') {
   buildOptions.vendorTrees = [
-    buildVendorPackage('@glimmer/compiler', { 
+    buildVendorPackage('@glimmer/compiler', {
       external: ['babel-helpers', '@glimmer/syntax', '@glimmer/wire-format', '@glimmer/util'] }),
-    buildVendorPackage('@glimmer/di', { 
-      external: ['babel-helpers', '@glimmer/util'] }),
-    buildVendorPackage('@glimmer/object-reference', { 
+    buildVendorPackage('@glimmer/di', {
+      external: ['babel-helpers'] }),
+    buildVendorPackage('@glimmer/object-reference', {
       external: ['babel-helpers', '@glimmer/util', '@glimmer/reference'] }),
-    buildVendorPackage('@glimmer/reference', { 
+    buildVendorPackage('@glimmer/reference', {
       external: ['babel-helpers', '@glimmer/util'] }),
     buildVendorPackage('@glimmer/runtime', {
-      external: ['babel-helpers', 
+      external: ['babel-helpers',
                  '@glimmer/util',
                  '@glimmer/reference',
                  '@glimmer/wire-format',
                  '@glimmer/syntax']}),
-    buildVendorPackage('@glimmer/syntax', { 
+    buildVendorPackage('@glimmer/syntax', {
       external: ['babel-helpers', 'handlebars', 'simple-html-tokenizer'] }),
-    buildVendorPackage('@glimmer/util', { 
+    buildVendorPackage('@glimmer/util', {
       external: ['babel-helpers'] }),
-    buildVendorPackage('@glimmer/wire-format', { 
+    buildVendorPackage('@glimmer/wire-format', {
       external: ['@glimmer/util'] }),
     buildVendorPackage('simple-html-tokenizer'),
-    funnel(path.dirname(require.resolve('handlebars/package')), { 
+    funnel(path.dirname(require.resolve('handlebars/package')), {
       include: ['dist/handlebars.amd.js'] })
   ];
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.7",
+    "@glimmer/di": "^0.1.9",
     "@glimmer/compiler": "^0.21.1",
     "@glimmer/interfaces": "^0.21.0",
     "@glimmer/object-reference": "^0.21.0",
@@ -29,7 +29,7 @@
     "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.2.1",
+    "@glimmer/build": "^0.3.0",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "testem": "^1.13.0"

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,14 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "amd",
+    "target": "es2017",
+    "module": "es2015",
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "inlineSources": true,
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "outFile": "tests/tests.js",
     "types": ["qunit"]
   },
   "include": [


### PR DESCRIPTION
@glimmer/di is no longer dependent on @glimmer/util.

@glimmer/build requires an update to tsconfig.tests.json