### PR TITLE
Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,21 +22,18 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@glimmer/util": "^0.23.0-alpha.6"
-  },
-  "peerDependencies": {
+    "@glimmer/util": "^0.23.0-alpha.11",
     "@glimmer/application": "^0.3.6",
     "@glimmer/di": "^0.1.9",
-    "@glimmer/reference": "^0.23.0-alpha.6",
-    "@glimmer/runtime": "^0.23.0-alpha.6"
+    "@glimmer/reference": "^0.23.0-alpha.11",
+    "@glimmer/runtime": "^0.23.0-alpha.11"
   },
   "devDependencies": {
-    "@glimmer/application": "^0.3.0",
     "@glimmer/build": "^0.6.1",
-    "@glimmer/compiler": "^0.23.0-alpha.6",
-    "@glimmer/interfaces": "^0.23.0-alpha.6",
+    "@glimmer/compiler": "^0.23.0-alpha.11",
+    "@glimmer/interfaces": "^0.23.0-alpha.11",
     "@glimmer/resolver": "^0.3.0",
-    "@glimmer/wire-format": "^0.23.0-alpha.6",
+    "@glimmer/wire-format": "^0.23.0-alpha.11",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "ember-cli": "^2.12.0",


### PR DESCRIPTION
Users get a warning even if another library has included the peer dependency.