### PR TITLE
Setting component `args` should not schedule a re-render

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -1,5 +1,5 @@
 import { Simple } from '@glimmer/runtime';
-import { tracked } from './tracked';
+import { metaFor } from './tracked';
 
 /**
  * The `Component` class defines an encapsulated UI element that is rendered to
@@ -162,7 +162,19 @@ class Component {
    * ```
    *
    */
-  @tracked args: object;
+  get args() {
+    return this.__args__;
+  }
+
+  set args(args) {
+    this.__args__ = args;
+    metaFor(this).dirtyableTagFor('args').inner.dirty();
+  }
+
+  /** @private
+   * Slot on the component to save Arguments object passed to the `args` setter.
+   */
+  private __args__: any = null;
 
   static create(injections: any) {
     return new this(injections);

--- a/test/args-test.ts
+++ b/test/args-test.ts
@@ -1,6 +1,7 @@
 import Component from '../src/component';
 import { tracked } from '../src/tracked';
 import buildApp from './test-helpers/test-app';
+import Application from "@glimmer/application";
 
 const { module, test } = QUnit;
 
@@ -68,4 +69,36 @@ test('Args smoke test', (assert) => {
     .boot();
 
   parent.firstName = "Thomas";
+});
+
+test("Setting args should not schedule a rerender", function(assert) {
+  let done = assert.async();
+  let app: Application;
+
+  class ParentComponent extends Component {
+    @tracked foo = false;
+
+    constructor(options: any) {
+      super(options);
+      setTimeout(() => {
+        this.foo = true;
+      }, 1);
+    }
+
+    didUpdate() {
+      assert.strictEqual(app['_scheduled'], false, 're-render has not been scheduled in update');
+      done();
+    }
+  }
+
+  class ChildComponent extends Component {
+  }
+
+  app = buildApp()
+    .template('main', '<div><parent-component /></div>')
+    .template('parent-component', '<div><child-component @foo={{foo}}></child-component></div>')
+    .component('parent-component', ParentComponent)
+    .template('child-component', '<div></div>')
+    .component('child-component', ChildComponent)
+    .boot();
 });


### PR DESCRIPTION
Historically, setting a tracked property triggered:

1. Invalidating the tracked property’s tag.
2. Scheduling a re-render.

However, in at least the case of a component’s `args` property, scheduling a re-render is not desirable. That’s because `args` are set by Glimmer during the render process, and a mutation never indicates that the DOM may update.

There _may_, however, be derived, computed state that should be invalidated by the changing `args`, which should happen before the component is updated. In that case, the tracked property semantics of invalidating a tag are desired, because it unlocks the ability to invalidate a component’s tracked computed properties.

This commit changes the component’s `args` property to use a special getter/setter instead of `@tracked`. This setter manually invalidates the property’s tag but does not schedule a re-render. This fixes an infinite re-rendering bug that some users were seeing (https://github.com/glimmerjs/glimmer-component/issues/45), where `args` were set over and over again.