### PR TITLE
Only monitor untracked properties in debug mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,10 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
+
+script:
+  - npm run test:$TEST_MODE
+
+env:
+  - TEST_MODE=debug
+  - TEST_MODE=prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 
 node_js:
   - "6"
-  - "node"
 
 addons:
   firefox: latest

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const build = require('@glimmer/build');
+const CreateFile = require('broccoli-file-creator');
 const packageDist = require('@glimmer/build/lib/package-dist');
 const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
 const funnel = require('broccoli-funnel');
@@ -18,8 +19,16 @@ module.exports = function() {
     '@glimmer/syntax',
     '@glimmer/util',
     '@glimmer/wire-format',
-    '@glimmer/env'
   ].map(packageDist);
+
+  vendorTrees.push(new CreateFile('glimmer-env.js', `
+    define('@glimmer/env', ['exports'], function(exports) {
+      'use strict';
+
+      exports.__esModule = true;
+      exports.DEBUG = ${process.env.TEST_MODE === 'debug'};
+    });
+  `));
 
   vendorTrees.push(buildVendorPackage('simple-html-tokenizer'));
   vendorTrees.push(funnel(path.dirname(require.resolve('handlebars/package')), {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -17,7 +17,8 @@ module.exports = function() {
     '@glimmer/runtime',
     '@glimmer/syntax',
     '@glimmer/util',
-    '@glimmer/wire-format'
+    '@glimmer/wire-format',
+    '@glimmer/env'
   ].map(packageDist);
 
   vendorTrees.push(buildVendorPackage('simple-html-tokenizer'));
@@ -33,7 +34,8 @@ module.exports = function() {
       '@glimmer/reference',
       '@glimmer/util',
       '@glimmer/runtime',
-      '@glimmer/di'
+      '@glimmer/di',
+      '@glimmer/env'
     ]
   });
 }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "test": "ember test"
   },
   "dependencies": {
-    "@glimmer/util": "^0.23.0-alpha.11",
     "@glimmer/application": "^0.3.6",
     "@glimmer/di": "^0.1.9",
+    "@glimmer/env": "^0.1.1",
     "@glimmer/reference": "^0.23.0-alpha.11",
-    "@glimmer/runtime": "^0.23.0-alpha.11"
+    "@glimmer/runtime": "^0.23.0-alpha.11",
+    "@glimmer/util": "^0.23.0-alpha.11"
   },
   "devDependencies": {
     "@glimmer/build": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@glimmer/application": "^0.3.6",
     "@glimmer/di": "^0.1.9",
-    "@glimmer/env": "^0.1.1",
+    "@glimmer/env": "^0.1.5",
     "@glimmer/reference": "^0.23.0-alpha.11",
     "@glimmer/runtime": "^0.23.0-alpha.11",
     "@glimmer/util": "^0.23.0-alpha.11"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "preversion": "npm run test",
     "prepublish": "npm run build",
     "postpublish": "git push origin master --tags",
-    "test": "ember test"
+    "test": "npm run test:prod",
+    "test:prod": "TEST_MODE=prod ember test",
+    "test:debug": "TEST_MODE=debug ember test"
   },
   "dependencies": {
     "@glimmer/application": "^0.3.6",
@@ -37,6 +39,7 @@
     "@glimmer/wire-format": "^0.23.0-alpha.11",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
+    "broccoli-file-creator": "^1.1.1",
     "ember-cli": "^2.12.0",
     "testem": "^1.13.0"
   }

--- a/src/tracked.ts
+++ b/src/tracked.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from '@glimmer/env';
 import { Tag, DirtyableTag, TagWrapper, combine, CONSTANT_TAG } from '@glimmer/reference';
 import { dict, Dict } from '@glimmer/util';
 
@@ -232,7 +233,7 @@ function defaultErrorThrower(obj: any, key: string): UntrackedPropertyError {
 
 export function tagForProperty(obj: any, key: string, throwError: UntrackedPropertyErrorThrower = defaultErrorThrower): Tag {
   if (typeof obj === 'object' && obj) {
-    if (!hasTag(obj, key)) {
+    if (DEBUG && !hasTag(obj, key)) {
       installDevModeErrorInterceptor(obj, key, throwError);
     }
 

--- a/test/rendering-test.ts
+++ b/test/rendering-test.ts
@@ -1,5 +1,6 @@
 import Component from '../src/component';
 import buildApp from './test-helpers/test-app';
+import { DEBUG } from '@glimmer/env';
 
 const { module, test } = QUnit;
 
@@ -15,28 +16,30 @@ test('A component can be rendered in a template', (assert) => {
   assert.equal(app.rootElement.textContent, 'Hello, Tom!');
 });
 
-test('Mutating a tracked property throws an exception', (assert) => {
-  let done = assert.async();
+if (DEBUG) {
+  test('Mutating a tracked property throws an exception', (assert) => {
+    let done = assert.async();
 
-  class HelloWorldComponent extends Component {
-    firstName: string;
+    class HelloWorldComponent extends Component {
+      firstName: string;
 
-    constructor(options: any) {
-      super(options);
+      constructor(options: any) {
+        super(options);
+      }
+
+      didInsertElement() {
+        assert.throws(() => {
+          this.firstName = 'Chad';
+        }, /The 'firstName' property on the hello-world component was changed after it had been rendered. Properties that change after being rendered must be tracked. Use the @tracked decorator to mark this as a tracked property./);
+
+        done();
+      }
     }
 
-    didInsertElement() {
-      assert.throws(() => {
-        this.firstName = 'Chad';
-      }, /The 'firstName' property on the hello-world component was changed after it had been rendered. Properties that change after being rendered must be tracked. Use the @tracked decorator to mark this as a tracked property./);
-
-      done();
-    }
-  }
-
-  buildApp()
-    .template('main', '<div><hello-world></hello-world></div>')
-    .template('hello-world', '<h1>Hello, {{firstName}} {{lastName}}!</h1>')
-    .component('hello-world', HelloWorldComponent)
-    .boot();
-});
+    buildApp()
+      .template('main', '<div><hello-world></hello-world></div>')
+      .template('hello-world', '<h1>Hello, {{firstName}} {{lastName}}!</h1>')
+      .component('hello-world', HelloWorldComponent)
+      .boot();
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,9 +73,9 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
-"@glimmer/env@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.1.tgz#f4c188dbfb07023e3161882af293df986eb307f8"
+"@glimmer/env@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.5.tgz#5ef458fd22843852344048003bc0638d7eeabd81"
 
 "@glimmer/interfaces@^0.23.0-alpha.11":
   version "0.23.0-alpha.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,10 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
+"@glimmer/env@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.1.tgz#f4c188dbfb07023e3161882af293df986eb307f8"
+
 "@glimmer/interfaces@^0.23.0-alpha.11":
   version "0.23.0-alpha.11"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.23.0-alpha.11.tgz#18454766efb4e545e74eb8efdf2d17eea81f1394"


### PR DESCRIPTION
* Adds `@glimmer/env` (which defaults to `DEBUG === false`).
* Adds customization to local build pipeline to allow testing of both prod and debug style builds.
* Guards tests that are testing debug only features (e.g. "mandatory setter" in debug builds).
* Add Travis CI builds for both `debug` and `prod` builds.

To truly support both debug and prod semantics for Glimmer applications we will also need to make `@glimmer/application-pipeline` aware (and have it use `babel-plugin-debug-macros` to replace `DEBUG` imported from `@glimmer/env` with `true` or `false` based on `process.env.EMBER_ENV`).

/cc @mmun