### PR TITLE
Revert "Setting component `args` should not schedule a re-render"

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -1,5 +1,5 @@
 import { Simple } from '@glimmer/runtime';
-import { metaFor } from './tracked';
+import { tracked } from './tracked';
 
 /**
  * The `Component` class defines an encapsulated UI element that is rendered to
@@ -162,19 +162,7 @@ class Component {
    * ```
    *
    */
-  get args() {
-    return this.__args__;
-  }
-
-  set args(args) {
-    this.__args__ = args;
-    metaFor(this).dirtyableTagFor('args').inner.dirty();
-  }
-
-  /** @private
-   * Slot on the component to save Arguments object passed to the `args` setter.
-   */
-  private __args__: any = null;
+  @tracked args: object;
 
   static create(injections: any) {
     return new this(injections);

--- a/test/args-test.ts
+++ b/test/args-test.ts
@@ -1,7 +1,6 @@
 import Component from '../src/component';
 import { tracked } from '../src/tracked';
 import buildApp from './test-helpers/test-app';
-import Application from "@glimmer/application";
 
 const { module, test } = QUnit;
 
@@ -69,36 +68,4 @@ test('Args smoke test', (assert) => {
     .boot();
 
   parent.firstName = "Thomas";
-});
-
-test("Setting args should not schedule a rerender", function(assert) {
-  let done = assert.async();
-  let app: Application;
-
-  class ParentComponent extends Component {
-    @tracked foo = false;
-
-    constructor(options: any) {
-      super(options);
-      setTimeout(() => {
-        this.foo = true;
-      }, 1);
-    }
-
-    didUpdate() {
-      assert.strictEqual(app['_scheduled'], false, 're-render has not been scheduled in update');
-      done();
-    }
-  }
-
-  class ChildComponent extends Component {
-  }
-
-  app = buildApp()
-    .template('main', '<div><parent-component /></div>')
-    .template('parent-component', '<div><child-component @foo={{foo}}></child-component></div>')
-    .component('parent-component', ParentComponent)
-    .template('child-component', '<div></div>')
-    .component('child-component', ChildComponent)
-    .boot();
 });


### PR DESCRIPTION
Reverts glimmerjs/glimmer-component#52

While testing master with this change it seems that we fixed the infinite rerender bug too well, and now no longer rerender at all 😜.

I'm reverting this for now while we track that down...