### PR TITLE
Make @glimmer/application a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:debug": "TEST_MODE=debug ember test"
   },
   "dependencies": {
-    "@glimmer/application": "^0.3.6",
     "@glimmer/di": "^0.1.9",
     "@glimmer/env": "^0.1.5",
     "@glimmer/reference": "^0.23.0-alpha.11",
@@ -32,6 +31,7 @@
     "@glimmer/util": "^0.23.0-alpha.11"
   },
   "devDependencies": {
+    "@glimmer/application": "^0.4.0",
     "@glimmer/build": "^0.6.1",
     "@glimmer/compiler": "^0.23.0-alpha.11",
     "@glimmer/interfaces": "^0.23.0-alpha.11",

--- a/src/component-definition.ts
+++ b/src/component-definition.ts
@@ -5,7 +5,7 @@ import {
 } from '@glimmer/runtime';
 import ComponentManager, { ComponentStateBucket } from './component-manager';
 import { ComponentFactory } from './component';
-import { TemplateMeta } from '@glimmer/application';
+import TemplateMeta from './template-meta';
 
 export default class ComponentDefinition extends GlimmerComponentDefinition<ComponentStateBucket> {
   componentFactory: ComponentFactory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { default as default,  ComponentFactory } from './component';
 export { default as ComponentDefinition } from './component-definition';
 export { default as ComponentManager } from './component-manager';
 export { tracked, setPropertyDidChange } from './tracked';
+export { default as TemplateMeta } from './template-meta';

--- a/src/template-meta.ts
+++ b/src/template-meta.ts
@@ -1,0 +1,8 @@
+import { TemplateMeta } from '@glimmer/wire-format';
+
+interface ExtendedTemplateMeta extends TemplateMeta {
+  specifier: string;
+  managerId?: string;
+}
+
+export default ExtendedTemplateMeta;

--- a/test/test-helpers/compiler.ts
+++ b/test/test-helpers/compiler.ts
@@ -5,7 +5,7 @@ import {
 import { 
   SerializedTemplateWithLazyBlock 
 } from "@glimmer/wire-format";
-import { TemplateMeta } from '@glimmer/application';
+import TemplateMeta from '../../src/template-meta';
 
 export function precompile(template: string, options: PrecompileOptions<TemplateMeta>): SerializedTemplateWithLazyBlock<TemplateMeta> {
   return JSON.parse(glimmerPrecompile(template, options));

--- a/test/test-helpers/test-app.ts
+++ b/test/test-helpers/test-app.ts
@@ -18,6 +18,7 @@ let moduleConfiguration = {
   types: {
     application: { definitiveCollection: 'main' },
     component: { definitiveCollection: 'components' },
+    helper: { definitiveCollection: 'components' },
     renderer: { definitiveCollection: 'main' },
     service: { definitiveCollection: 'services' },
     template: { definitiveCollection: 'components' },
@@ -30,7 +31,7 @@ let moduleConfiguration = {
     },
     components: {
       group: 'ui',
-      types: ['component', 'template']
+      types: ['component', 'template', 'helper']
     },
     services: {
       types: ['service']


### PR DESCRIPTION
Move the definition of `TemplateMeta` used in glimmer apps from 
@glimmer/application into @glimmer/component, removing the only run-time
dependency on @glimmer/application.
