### PR TITLE
Expose `RootReference`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { default as ComponentDefinition } from "./component-definition";
 export { default as ComponentManager } from "./component-manager";
 export { tracked, setPropertyDidChange } from "./tracked";
 export { default as TemplateMeta } from './template-meta';
+export { RootReference } from './references';


### PR DESCRIPTION
Helpful if you're trying to write a custom component manager. It's needed in the `getSelf` method, e.g.:

```ts
getSelf({ component }: ComponentStateBucket): RootReference {
  return new RootReference(component);
}
```