### PR TITLE
Monorepo preparation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "preversion": "npm run test",
     "prepublish": "npm run build",
     "postpublish": "git push origin master --tags",
-    "test": "npm run test:prod",
+    "test": "tslint --project tsconfig.json && npm run test:prod",
     "test:prod": "TEST_MODE=prod ember test",
     "test:debug": "TEST_MODE=debug ember test"
   },
@@ -42,6 +42,7 @@
     "broccoli-cli": "^1.0.0",
     "broccoli-file-creator": "^1.1.1",
     "ember-cli": "^2.12.0",
-    "testem": "^1.13.0"
+    "testem": "^1.13.0",
+    "tslint": "^5.6.0"
   }
 }

--- a/src/component-manager.ts
+++ b/src/component-manager.ts
@@ -100,7 +100,7 @@ export default class ComponentManager implements GlimmerComponentManager<Compone
         create(injections: object) {
           return this.class.create(injections);
         }
-      }
+      };
     }
 
     return new ComponentDefinition(name, this, template, componentFactory);
@@ -125,7 +125,7 @@ export default class ComponentManager implements GlimmerComponentManager<Compone
   }
 
   didCreate(bucket: ComponentStateBucket) {
-    bucket && bucket.component.didInsertElement();
+    if (bucket) { bucket.component.didInsertElement(); }
   }
 
   getTag({ tag }: ComponentStateBucket): Tag {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { default,  ComponentFactory } from "./component";
+export { default, ComponentFactory } from "./component";
 export { default as ComponentDefinition } from "./component-definition";
 export { default as ComponentManager } from "./component-manager";
-export { tracked, setPropertyDidChange } from "./tracked";
+export { tracked, setPropertyDidChange, tagForProperty, UntrackedPropertyError } from "./tracked";
 export { default as TemplateMeta } from './template-meta';

--- a/test/args-test.ts
+++ b/test/args-test.ts
@@ -1,7 +1,5 @@
-import Component from '../src/component';
-import { tracked } from '../src/tracked';
+import Component, { tracked, setPropertyDidChange } from '../src/index';
 import buildApp, { TestApplication } from './test-helpers/test-app';
-import { setPropertyDidChange } from '../src/tracked';
 import { didRender } from '@glimmer/application-test-helpers';
 
 const { module, test } = QUnit;

--- a/test/component-test.ts
+++ b/test/component-test.ts
@@ -1,4 +1,4 @@
-import Component from '../src/component';
+import Component from '../src/index';
 import buildApp from './test-helpers/test-app';
 import { getOwner } from '@glimmer/di';
 

--- a/test/component-test.ts
+++ b/test/component-test.ts
@@ -22,7 +22,7 @@ test('can be instantiated with an owner', function(assert) {
     .template('main', '<div><hello-world></hello-world></div>')
     .template('hello-world', '<div>Hello world</div>')
     .component('hello-world', MyComponent)
-    .boot()
+    .boot();
 
   assert.ok(component, 'component exists');
   assert.strictEqual(getOwner(component), app, 'owner has been set');

--- a/test/lifecycle-hook-test.ts
+++ b/test/lifecycle-hook-test.ts
@@ -9,7 +9,7 @@ test('Lifecycle hook ordering', (assert) => {
   assert.expect(7);
 
   let invocations: [string, string][] = [];
-  let didCallWillDestroy: boolean = false;
+  let didCallWillDestroy = false;
 
   abstract class HookLoggerComponent extends Component {
     abstract name: string;
@@ -24,11 +24,11 @@ test('Lifecycle hook ordering', (assert) => {
     }
   }
 
-  class Component1 extends HookLoggerComponent { name = 'component1' }
-  class Component2 extends HookLoggerComponent { name = 'component2' }
-  class Component3 extends HookLoggerComponent { name = 'component3' }
-  class Component4 extends HookLoggerComponent { name = 'component4' }
-  class Component5 extends HookLoggerComponent { name = 'component5' }
+  class Component1 extends HookLoggerComponent { name = 'component1'; };
+  class Component2 extends HookLoggerComponent { name = 'component2'; };
+  class Component3 extends HookLoggerComponent { name = 'component3'; };
+  class Component4 extends HookLoggerComponent { name = 'component4'; };
+  class Component5 extends HookLoggerComponent { name = 'component5'; };
 
   let app = buildApp()
     .template('main', '<div><component-one /></div>')

--- a/test/lifecycle-hook-test.ts
+++ b/test/lifecycle-hook-test.ts
@@ -1,4 +1,4 @@
-import Component from '../src/component';
+import Component from '../src/index';
 import buildApp from './test-helpers/test-app';
 
 const { module, test } = QUnit;

--- a/test/rendering-test.ts
+++ b/test/rendering-test.ts
@@ -1,4 +1,4 @@
-import Component from '../src/component';
+import Component from '../src/index';
 import buildApp from './test-helpers/test-app';
 import { DEBUG } from '@glimmer/env';
 

--- a/test/test-helpers/test-app.ts
+++ b/test/test-helpers/test-app.ts
@@ -7,7 +7,7 @@ export class TestApplication extends Application {
   rootElement: Simple.Element;
 }
 
-export default function buildApp(appName: string = 'test-app', options: AppBuilderOptions = {}): AppBuilder {
+export default function buildApp(appName = 'test-app', options: AppBuilderOptions = {}): AppBuilder {
   options.ApplicationClass = options.ApplicationClass || TestApplication;
   options.ComponentManager = options.ComponentManager || ComponentManager;
   return new AppBuilder(appName, options);

--- a/test/test-helpers/test-app.ts
+++ b/test/test-helpers/test-app.ts
@@ -1,7 +1,7 @@
 import Application from '@glimmer/application';
 import { Simple } from '@glimmer/interfaces';
 import { AppBuilder, AppBuilderOptions } from '@glimmer/application-test-helpers';
-import ComponentManager from '../../src/component-manager';
+import { ComponentManager } from '../../src/index';
 
 export class TestApplication extends Application {
   rootElement: Simple.Element;

--- a/test/tracked-property-test.ts
+++ b/test/tracked-property-test.ts
@@ -118,7 +118,7 @@ test('tracked computed properties are invalidated when their dependencies are in
 
     @tracked('firstName', 'lastName')
     get fullName() {
-      return `${this.firstName} ${this.lastName}`
+      return `${this.firstName} ${this.lastName}`;
     }
     set fullName(fullName) {
       let [firstName, lastName] = fullName.split(' ');
@@ -174,7 +174,7 @@ if (DEBUG) {
   });
 
   test('interceptor works correctly for inherited value descriptor', (assert) => {
-    class Person { name: string }
+    class Person { name: string; }
     Person.prototype.name = 'Martin';
 
     let obj = new Person();
@@ -193,7 +193,7 @@ if (DEBUG) {
       get name() {
         return 'Martin';
       }
-    }
+    };
 
     tagForProperty(obj, 'name');
 
@@ -223,7 +223,7 @@ if (DEBUG) {
   });
 
   test('interceptor works correctly for inherited non-configurable descriptor', (assert) => {
-    class Person { name: string }
+    class Person { name: string; }
     Person.prototype.name = 'Martin';
     Object.defineProperty(Person.prototype, 'name', { configurable: false });
 

--- a/test/tracked-property-test.ts
+++ b/test/tracked-property-test.ts
@@ -1,7 +1,7 @@
 const { module, test } = QUnit;
 
 import { DEBUG } from '@glimmer/env';
-import { tracked, tagForProperty, UntrackedPropertyError } from '../src/tracked';
+import { tracked, tagForProperty, UntrackedPropertyError } from '../src/index';
 import { CONSTANT_TAG } from "@glimmer/reference";
 
 module('Tracked Properties');

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,21 @@
+{
+  "rules": {
+    "curly": false,
+    "no-var-keyword": true,
+    "indent": [true, "spaces"],
+    "label-position": true,
+    "no-consecutive-blank-lines": [
+      true
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-variable": true,
+    "no-inferrable-types": [true],
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "semicolon": [true, "always"],
+    "triple-equals": true,
+    "class-name": true,
+    "no-require-imports": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,6 +757,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -823,6 +827,13 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -1315,6 +1326,10 @@ commander@^2.5.0, commander@^2.6.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
@@ -1577,6 +1592,10 @@ diff@^1.3.1:
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
+
+diff@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -2327,6 +2346,17 @@ glob@^5.0.10, glob@^5.0.15, glob@~5.0.0:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3109,6 +3139,12 @@ minimatch@^2.0.3:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -4063,6 +4099,10 @@ tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
 
+tslib@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+
 tslint@^3.15.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-3.15.1.tgz#da165ca93d8fdc2c086b51165ee1bacb48c98ea5"
@@ -4074,6 +4114,27 @@ tslint@^3.15.1:
     optimist "~0.6.0"
     resolve "^1.1.7"
     underscore.string "^3.3.4"
+
+tslint@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.6.0.tgz#088aa6c6026623338650b2900828ab3edf59f6cf"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    colors "^1.1.2"
+    commander "^2.9.0"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.7.1"
+    tsutils "^2.7.1"
+
+tsutils@^2.7.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
+  dependencies:
+    tslib "^1.7.1"
 
 type-is@~1.6.14:
   version "1.6.14"


### PR DESCRIPTION
This PR makes two changes in preparation of including `@glimmer/component` in a `glimmer.js` monorepo:

1. Tests import from the package root (`index.js`) rather than nested modules. This facilitates running tests against production builds of packages, where internal modules get hoisted into variable scope and any path information is loss. (That is, you can only `require('@glimmer/component')`, not `require('@glimmer/component/src/tracked')`.)
2. Adopts the tslint config from `glimmer-vm`.